### PR TITLE
More RAM + more warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,9 @@ CARGO := cargo
 XARGO := xargo
 KCOV := kcov
 RUSTFILES := src/*.rs
-RUSTFLAGS='-C relocation-model=static'
+RUSTFLAGS='-C relocation-model=static --deny warnings'
 CARFOFEATURES="runtime_tests"
+ccflags-y := -Wall -Werror
 
 all: $(MODULENAME).ko
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,6 +7,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.provider :libvirt do |libvirt|
     libvirt.cpus = 2
+    libvirt.memory = 2048
     libvirt.nested = true
   end
 


### PR DESCRIPTION
Be a little bit more strict about warnings. Also, the default VM has far too little memory.