### PR TITLE
Rustyvisor should run under other hypervisors

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,6 +3,9 @@
 set -x
 set -e
 
+
+OS="`uname`"
+
 if [ "$1" = "clean" ] ; then
     cd uefi || exit 255
     cargo clean
@@ -27,6 +30,17 @@ cd rustyvctl || exit 255
 cargo build
 cd ..
 
+if [ "$OS" = "Linux" ]; then
+
 cd linux || exit 255
 make
 cd ..
+
+else
+
+echo "On a non-Linux OS. I will only build the rust parts of the Linux Kernel Module version of RustyVisor"
+cd linux || exit 255
+make rust-only
+cd ..
+
+fi

--- a/hypervisor/src/vmx.rs
+++ b/hypervisor/src/vmx.rs
@@ -19,7 +19,6 @@ pub enum CPUIDLeaf {
 #[repr(u32)]
 pub enum CPUIDLeafProcessorInfoAndFeaturesECXBits {
     VMXAvailable = 1 << 5,
-    HypervisorPresent = 1 << 31,
 }
 
 pub const fn is_page_aligned(n: u64) -> bool {
@@ -57,7 +56,6 @@ pub fn read_dr7() -> u64 {
 fn vmx_available() -> bool {
     let result = unsafe { core::arch::x86_64::__cpuid(CPUIDLeaf::ProcessorInfoAndFeatures as u32) };
     result.ecx & (CPUIDLeafProcessorInfoAndFeaturesECXBits::VMXAvailable as u32) != 0
-        && result.ecx & (CPUIDLeafProcessorInfoAndFeaturesECXBits::HypervisorPresent as u32) == 0
 }
 
 /// Gets the current VMCS revision identifier.

--- a/linux/Makefile
+++ b/linux/Makefile
@@ -28,9 +28,12 @@ liblinux.o: $(RUST_LIB_PATH)
 	@cp $(realpath $<) $@
 	@echo "cmd_$(realpath $@) := cp $< $@" > .liblinux.o.cmd
 
+rust-only: $(RUST_LIB_PATH)
+
 clean:
 	$(MAKE) -C $(KDIR) M=$(PWD) clean
 
 clean-all: clean
 	$(CARGO) clean
 
+.PHONY: clean clean-all rust-only

--- a/scripts/ci-install.sh
+++ b/scripts/ci-install.sh
@@ -5,4 +5,10 @@ set -e
 
 source ~/.cargo/env
 
+# Install Linux Kernel headers
 sudo apt-get install linux-headers-$(uname -r)
+
+# Install UEFI Rust target
+rustup target install x86_64-unknown-uefi
+# Install Rust source code
+rustup component add rust-src

--- a/scripts/ci-install.sh
+++ b/scripts/ci-install.sh
@@ -8,6 +8,10 @@ source ~/.cargo/env
 # Install Linux Kernel headers
 sudo apt-get install linux-headers-$(uname -r)
 
+# Install and default to a nightly version of Rust
+rustup install nightly
+rustup default nightly
+
 # Install UEFI Rust target
 rustup target install x86_64-unknown-uefi
 # Install Rust source code


### PR DESCRIPTION
Addresses some of the issues which @lucabe72 mentioned in #54.

Also, now we won't try to build Linux Kernel Module bits on non-linux OSs